### PR TITLE
Unpin `markdown-link-check`

### DIFF
--- a/cast_checks/tests/ci.rs
+++ b/cast_checks/tests/ci.rs
@@ -51,10 +51,8 @@ fn license() {
 fn markdown_link_check() {
     let tempdir = tempdir().unwrap();
 
-    // smoelius: Pin `markdown-link-check` to version 3.10.3 until the following issue is resolved:
-    // https://github.com/tcort/markdown-link-check/issues/246
     Command::new("npm")
-        .args(["install", "markdown-link-check@3.10.3"])
+        .args(["install", "markdown-link-check"])
         .current_dir(&tempdir)
         .assert()
         .success();


### PR DESCRIPTION
https://github.com/tcort/markdown-link-check/releases/tag/v3.11.2