### PR TITLE
Adjust `inner_attribute_example` line numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ This will cause `cast_checks` to dump to standard output:
 Example:
 
 ```text
-cast_checks rewriting `x as u16` at src/lib.rs:0:0
-cast_checks not descending into `mod c ;` at src/lib.rs:0:0
+cast_checks rewriting `x as u16` at src/lib.rs:3:0
+cast_checks not descending into `mod c ;` at src/lib.rs:3:0
 ```
 
 Note that `CAST_CHECKS_LOG` requires `--cfg procmacro2_semver_exempt` to be passed to rustc.

--- a/cast_checks/tests/inner_attribute_example.rs
+++ b/cast_checks/tests/inner_attribute_example.rs
@@ -13,8 +13,8 @@ fn build() {
         command.env("CAST_CHECKS_LOG", "1");
         command.assert().success().stdout(
             "\
-cast_checks rewriting `x as u16` at src/lib.rs:0:0
-cast_checks not descending into `mod c;` at src/lib.rs:0:0
+cast_checks rewriting `x as u16` at src/lib.rs:3:0
+cast_checks not descending into `mod c;` at src/lib.rs:3:0
 ",
         );
     });
@@ -26,7 +26,7 @@ fn test() {
         command.assert().failure().stdout(predicates::str::contains(
             "\
 thread 'checked_truncation' panicked at src/lib.rs:3:1:
-invalid cast in `x as u16` at src/lib.rs:0:0: TryFromIntError(())
+invalid cast in `x as u16` at src/lib.rs:3:0: TryFromIntError(())
 ",
         ));
     });


### PR DESCRIPTION
I'm not certain, but https://github.com/dtolnay/proc-macro2/pull/472 may be what required them to change.